### PR TITLE
gofmt+add missing param to MsgBoxErr

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func myMain() {
 	var cmd *exec.Cmd
 	var timer *time.Timer
 	var timerChan <-chan time.Time
+	var w *ui.Window
 
 	status := ui.NewLabel("")
 
@@ -49,13 +50,13 @@ func myMain() {
 		if cmd != nil { // stop the command if it's running
 			err := cmd.Process.Kill()
 			if err != nil {
-				ui.MsgBoxError(
+				ui.MsgBoxError(w,
 					fmt.Sprintf("Error killing process: %v", err),
 					"You may need to kill it manually.")
 			}
 			err = cmd.Process.Release()
 			if err != nil {
-				ui.MsgBoxError(
+				ui.MsgBoxError(w,
 					fmt.Sprintf("Error releasing process: %v", err),
 					"")
 			}
@@ -69,7 +70,7 @@ func myMain() {
 		status.SetText("")
 	}
 
-	w := ui.NewWindow("wakeup", 400, 100)
+	w = ui.NewWindow("wakeup", 400, 100)
 	ui.AppQuit = w.Closing // treat application close as main window close
 	cmdbox := ui.NewLineEdit(defCmdLine)
 	timebox := ui.NewLineEdit(defTime)
@@ -104,7 +105,7 @@ mainloop:
 			stop() // only one alarm at a time
 			alarmTime, err := time.Parse(timeFmt, timebox.Text())
 			if err != nil {
-				ui.MsgBoxError(
+				ui.MsgBoxError(w,
 					fmt.Sprintf("Error parsing time %q: %v", timebox.Text(), err),
 					fmt.Sprintf("Make sure your time is in the form %q (without quotes).", timeFmt))
 				continue
@@ -122,7 +123,7 @@ mainloop:
 			err := cmd.Start()
 			status.SetText("Firing")
 			if err != nil {
-				ui.MsgBoxError(
+				ui.MsgBoxError(w,
 					fmt.Sprintf("Error running program: %v", err),
 					"")
 				cmd = nil

--- a/main.go
+++ b/main.go
@@ -6,18 +6,19 @@ import (
 	"os"
 	"os/exec"
 	"time"
+
 	"github.com/andlabs/ui"
 )
 
 const (
 	defCmdLine = "mpv -loop inf ~/ring.wav"
-	defTime = "10:30 AM"
-	timeFmt = "3:04 PM"
+	defTime    = "10:30 AM"
+	timeFmt    = "3:04 PM"
 )
 
 // If later hasn't happened yet, make it happen on the day of now; if not, the day after.
 func bestTime(now time.Time, later time.Time) time.Time {
-	now = now.Local()		// use local time to make things make sense
+	now = now.Local() // use local time to make things make sense
 	nowh, nowm, nows := now.Clock()
 	laterh, laterm, laters := later.Clock()
 	add := false
@@ -45,7 +46,7 @@ func myMain() {
 	status := ui.NewLabel("")
 
 	stop := func() {
-		if cmd != nil {		// stop the command if it's running
+		if cmd != nil { // stop the command if it's running
 			err := cmd.Process.Kill()
 			if err != nil {
 				ui.MsgBoxError(
@@ -60,7 +61,7 @@ func myMain() {
 			}
 			cmd = nil
 		}
-		if timer != nil {		// stop the timer if we started it
+		if timer != nil { // stop the timer if we started it
 			timer.Stop()
 			timer = nil
 			timerChan = nil
@@ -69,7 +70,7 @@ func myMain() {
 	}
 
 	w := ui.NewWindow("wakeup", 400, 100)
-	ui.AppQuit = w.Closing		// treat application close as main window close
+	ui.AppQuit = w.Closing // treat application close as main window close
 	cmdbox := ui.NewLineEdit(defCmdLine)
 	timebox := ui.NewLineEdit(defTime)
 	bStart := ui.NewButton("Start")
@@ -86,10 +87,10 @@ func myMain() {
 	grid := ui.NewGrid(2,
 		ui.NewLabel("Command"), cmdbox,
 		ui.NewLabel("Time"), timebox,
-		ui.Space(), ui.Space(),		// the Space on the right will consume the window blank space
+		ui.Space(), ui.Space(), // the Space on the right will consume the window blank space
 		ui.Space(), btnbox)
-	grid.SetStretchy(2, 1)			// make the Space noted above consume
-	grid.SetFilling(0, 1)				// make the two textboxes grow horizontally
+	grid.SetStretchy(2, 1) // make the Space noted above consume
+	grid.SetFilling(0, 1)  // make the two textboxes grow horizontally
 	grid.SetFilling(1, 1)
 
 	w.Open(grid)
@@ -100,7 +101,7 @@ mainloop:
 		case <-w.Closing:
 			break mainloop
 		case <-bStart.Clicked:
-			stop()		// only one alarm at a time
+			stop() // only one alarm at a time
 			alarmTime, err := time.Parse(timeFmt, timebox.Text())
 			if err != nil {
 				ui.MsgBoxError(
@@ -114,7 +115,7 @@ mainloop:
 			timerChan = timer.C
 			status.SetText("Started")
 		case <-timerChan:
-			cmd = exec.Command("/bin/sh", "-c", "exec " + cmdbox.Text())
+			cmd = exec.Command("/bin/sh", "-c", "exec "+cmdbox.Text())
 			// keep stdin /dev/null in case user wants to run multiple alarms on one instance (TODO should I allow this program to act as a pipe?)
 			// keep stdout /dev/null to avoid stty mucking
 			cmd.Stderr = os.Stderr


### PR DESCRIPTION
Hi,

I just fixed the missing `*ui.Window` parent parameter to the `ui.MsgBoxError()` calls.
