### PR TITLE
Replace label and break with defer and return

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,12 +95,13 @@ func myMain() {
 	grid.SetFilling(1, 1)
 
 	w.Open(grid)
+	
+	defer stop()
 
-mainloop:
 	for {
 		select {
 		case <-w.Closing:
-			break mainloop
+			return
 		case <-bStart.Clicked:
 			stop() // only one alarm at a time
 			alarmTime, err := time.Parse(timeFmt, timebox.Text())
@@ -135,9 +136,6 @@ mainloop:
 			stop()
 		}
 	}
-
-	// clean up
-	stop()
 }
 
 func main() {


### PR DESCRIPTION
Labels and outer breaks are not very elegant, so I'm proposing using a simple `return` instead of the `break` and deferring the `stop()` using a language feature. This makes clear that `stop()` is a cleanup action and the code inside the main loop doesn't have to worry about it.
