### PR TITLE
Increase starting height

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func myMain() {
 		status.SetText("")
 	}
 
-	w = ui.NewWindow("wakeup", 400, 100)
+	w = ui.NewWindow("wakeup", 400, 120)
 	ui.AppQuit = w.Closing // treat application close as main window close
 	cmdbox := ui.NewLineEdit(defCmdLine)
 	timebox := ui.NewLineEdit(defTime)


### PR DESCRIPTION
The default values result in a overlapping controls in Windows. By adding 20 extra pixels to the starting height the controls start at a more correct position.
